### PR TITLE
Добавил возможность выбора приложения для звонка

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,13 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-feature
-        android:name="android.hardware.telephony"
-        android:required="false" />
-
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.CALL_PHONE"/>
 
     <application
         android:name=".common.App"

--- a/app/src/main/java/ru/practicum/android/diploma/vacancy/data/repositoryImpl/VacancyRepositoryImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/vacancy/data/repositoryImpl/VacancyRepositoryImpl.kt
@@ -47,9 +47,4 @@ class VacancyRepositoryImpl(
         }
     }
 
-    companion object {
-        const val NO_CONNECTION = -1
-        const val RESPONSE_SUCCESS = 200
-    }
-
 }

--- a/app/src/main/java/ru/practicum/android/diploma/vacancy/di/vacancyModule.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/vacancy/di/vacancyModule.kt
@@ -34,9 +34,8 @@ val vacancyModule = module {
     single<ShareVacancyByIdUseCase> { ShareVacancyByIdUseCaseImpl(get()) }
     single<CallPhoneUseCase> { CallPhoneUseCaseImpl(get()) }
 
-    viewModel { (vacancyId: Int) ->
+    viewModel {
         VacancyViewModel(
-            vacancyId = vacancyId,
             findVacancyByIdUseCase = get(),
             addOrDelVacancyUseCase = get(),
             checkInFavoritesUseCase = get(),

--- a/app/src/main/java/ru/practicum/android/diploma/vacancy/ui/navigator/ExternalNavigatorImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/vacancy/ui/navigator/ExternalNavigatorImpl.kt
@@ -20,8 +20,9 @@ class ExternalNavigatorImpl(private val context: Context) : ExternalNavigator {
 
     override fun callPhone(phoneNumber: String) {
         val uri = Uri.parse("tel:$phoneNumber")
-        val intent = Intent(Intent.ACTION_DIAL, uri)
-        startActivityOrShowError(intent)
+        val intent = Intent(Intent.ACTION_VIEW, uri)
+        val chooser = Intent.createChooser(intent,null)
+        startActivityOrShowError(chooser)
     }
 
     override fun shareVacancyById(id: Int) {

--- a/app/src/main/java/ru/practicum/android/diploma/vacancy/ui/viewModel/VacancyViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/vacancy/ui/viewModel/VacancyViewModel.kt
@@ -15,7 +15,6 @@ import ru.practicum.android.diploma.vacancy.domain.useCase.ShareVacancyByIdUseCa
 import ru.practicum.android.diploma.vacancy.ui.VacancyState
 
 class VacancyViewModel(
-    private val vacancyId: Int,
     private val findVacancyByIdUseCase: FindVacancyByIdUseCase,
     private val addOrDelVacancyUseCase: AddOrDelVacancyUseCase,
     private val checkInFavoritesUseCase: CheckInFavoritesUseCase,


### PR DESCRIPTION
Однако при выборе приложения также всплывают неуместные варианты: Например банковские приложения, предлагающие перевод на данный номер

В подсказках к данной задаче, пишут, что тот вариант, который сейчас в dev должен работать.

" При нажатии на номер телефона пользователь должен выбрать приложение для звонков. Для этого используется ACTION_DIAL: Intent(Intent.ACTION_DIAL).apply {
    data = Uri.parse("tel:" + "phone_number")
} "

Удалил лишний код из VacancyRepositoryImpl